### PR TITLE
Add `rustfmt.toml` and remove a majority of `clippy` warnings

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+fn_single_line = true
+max_width = 120

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-fn_single_line = true
-max_width = 120

--- a/src/editors.rs
+++ b/src/editors.rs
@@ -6,7 +6,7 @@ pub trait Editor<T> {
         let mut ret_path = String::new();
 
         match env::var_os("PATH") {
-            Some(path_var) =>
+            Some(path_var) => {
                 for path in env::split_paths(&path_var) {
                     if Path::new(
                         format!(
@@ -33,7 +33,8 @@ pub trait Editor<T> {
                     {
                         ret_path = path.to_str().unwrap().to_string();
                     }
-                },
+                }
+            }
             None => return Err("Cannot find PATH environment variable".to_string()),
         };
 


### PR DESCRIPTION
First of all, I want to thank you for your project, and I would like to lend a hand refactoring it (to leverage the `clap` library, for example).

But before we really get started with that, I have noticed that you use a non-default formatter setting, which, for the collaborators' convenience, is best specified explicitly in the repo-wide `rustfmt.toml` file.
I have written 2 rules to begin with, and if you have more rules than that, feel free to add them too.

I have also fixed a majority of `clippy` warnings in passing. If you don't want those changes, just ignore them instead. :)